### PR TITLE
Add command flags with description to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ yarn add -D tscpaths
   "build": "tsc --project tsconfig.json && tscpaths -p tsconfig.json -s ./src -o ./out",
 }
 ```
+
+### Options
+| flag         | description                                        |
+| ------------ | -------------------------------------------------- |
+| -p --project | project configuration file (tsconfig.json)         |
+| -s --src     | source code root directory                         |
+| -o --out     | output directory of transpiled code (tsc --outDir) |
+
 You need to provide -s (--src) and -o (--out), because it's hard to predict source and output paths based on tsconfig.json.
 
 I've tried a little and failed. :(


### PR DESCRIPTION
Added a bit more detail for the required options.

Motivation for adding:
I was a bit confused with src and out dir. I expected src to be tsc outdir and out to be the output dir for the updated transpiled files.