### PR TITLE
handle node_modules paths, and use module name instead of relative path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,10 @@ verboseLog(`aliases: ${JSON.stringify(aliases, null, 2)}`);
 
 const toRelative = (from: string, x: string): string => {
   const rel = relative(from, x);
+
+  const matchNodeModules = x.match(/.*\/node_modules\//);
+  if (matchNodeModules) return relative(matchNodeModules[0], x);
+
   return (rel.startsWith('.') ? rel : `./${rel}`).replace(/\\/g, '/');
 };
 


### PR DESCRIPTION
Assume we have 

```javascript
import myModule from 'awesomeModule';
```

and in `tsconfig-esm.json`

```json
    "baseUrl": ".",
    "paths": {
      "awesomeModule": ["./node_modules/awesomeModule/dist/esm/index.js"]
    }
```

and in `tsconfig-cjs.json`

```json
    "baseUrl": ".",
    "paths": {
      "awesomeModule": ["./node_modules/awesomeModule/dist/cjs/index.js"]
    }
```

In that case, it should resolve as `awesomeModule/dist/cjs/index.js` and `awesomeModule/dist/esm/index.js` respectively. But currently, it resolved as relative paths, and fails, as `import` statement made from source code, and now it's in `dist` folder, which make relative paths broken, e.g. `Error: Cannot find module <PATH>/dist/node_modules/awesomeModule/dist/esm/index.js`.

